### PR TITLE
add more mongodb fields

### DIFF
--- a/server/models/JournalEntry.js
+++ b/server/models/JournalEntry.js
@@ -24,7 +24,13 @@ const entrySchema = new Schema({
     }],
     flairs: {type: [String], default: []},   
     // keywords which will be displayed on a card (ex: birthday, passed exam, had breakup)
-    dateCreated: {type: Date, default: Date.now}
+    numberHotWords: {type: Number, immutable: true, default: 0},
+    numberRedHotWords: {type: Number, immutable: true, default: 0},
+    numberBlacklistedWords: {type: Number, immutable: true, default: 0},
+    isExplicit: {type: Boolean, immutable: true, default: false},
+    isTooExplicit: {type: Boolean, immutable: true, default: false},
+    averageKeywordMagnitude: {type: Number, immutable: true, default: 0},
+    dateCreated: {type: Date, default: Date.now},
 })
 
 const JournalEntry = model("JournalEntry", entrySchema)


### PR DESCRIPTION
Notes:
added fields:

1. add numberHotWords that counts the number of hot words.
2. numberRedHotWords: counts the number of red hot words},
3. numberBlackListedWords: counts number of blacklisted words
4. isExplicit: is set if there is at least 1 redhot word in title or entry
5. isTooExplicit: is set if there is at least 1 blacklisted word in title or entry
6. averageKeyword magnitude: average magnitude of all the entries.

Note: totalEventAbsoluteWeight not implemented because the stats to find most eventful entries will be done through a pipeline.
